### PR TITLE
fix unintended error shown in latest version of mypy

### DIFF
--- a/Chapter 03/ch03_r04.py
+++ b/Chapter 03/ch03_r04.py
@@ -12,9 +12,9 @@ def temperature(*,
     f_temp: Optional[Number]=None,
     c_temp: Optional[Number]=None) -> Mapping[str, Number]:
 
-    if c_temp is None:
+    if c_temp is None and f_temp is not None:
         c_temp = 5*(f_temp-32)/9
-    elif f_temp is None:
+    elif f_temp is None and c_temp is not None:
         f_temp = 32+9*c_temp/5
     else:
         raise Exception( "Logic Design Problem" )
@@ -27,9 +27,9 @@ def temperature_bad(*,
     f_temp: Optional[Number]=None,
     c_temp: Optional[Number]=None) -> Number:
 
-    if c_temp is None:
+    if c_temp is None and f_temp is not None:
         c_temp = 5*(f_temp-32)/9
-    elif f_temp is None:
+    elif f_temp is None and c_temp is not None:
         f_temp = 32+9*c_temp/5
     else:
         raise Exception( "Logic Design Problem" )


### PR DESCRIPTION
This chapter discusses using mypy to find static typing errors in code. However, when using mypy 0.67 on this code it also reports a logical error in the case where both optional parameters are None. Since this is somewhat confusing to new learners it seems sensible to just patch the code so it only displays the original intended error rather than these additional logic errors.